### PR TITLE
Expand peerDep range

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Ash Furrow <ash@ashfurrow.com> & Art.sy Inc",
   "license": "MIT",
   "peerDependencies": {
-    "graphql": "^14.0.2"
+    "graphql": "^13.0.0 || ^14.0.0"
   },
   "devDependencies": {
     "@types/jest": "^23.3.2",


### PR DESCRIPTION
Expands range to silence some peerDep warnings for those on different versions of `graphql`. 