### PR TITLE
Fixes Danger config on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ cache:
 script:
 - yarn lint
 - yarn jest
-- yarn danger ci
+- '[ ! -z $DANGER_GITHUB_API_TOKEN ] && yarn danger ci || echo "Skipping Danger for External Contributor"'
+


### PR DESCRIPTION
I've removed the encrypted Danger token from Travis config and put it in their dashboard. As I explained in #6, this is for @ashfurrowbot, who has no privileges so it's as safe as any Danger bot account. 

I've made this PR from my fork to test.

Fixes #10.